### PR TITLE
Switch to ledger contract based specification of price oracles.

### DIFF
--- a/dabl-meta.yaml
+++ b/dabl-meta.yaml
@@ -4,7 +4,7 @@
 catalog:
     name: dabl-integration-coindesk
     group_id: com.digitalasset
-    version: 0.6.0
+    version: 0.7.0
     short_description: CoinDesk
     description: BTC Price Queries
     author: Digital Asset (Switzerland) GmbH
@@ -22,14 +22,5 @@ integration_types:
       name: CoinDesk Price Oracle
       description: Periodically queries CoinDesk for the price of BTC in a specific unit of currency and updates a CurrentPrice contract on the ledger with that price.
       entrypoint: core_int.integration_coindesk_price:integration_coindesk_price_oracle_main
-      env_class: core_int.integration_coindesk_price:IntegrationCoinDeskPriceOracleEnv
       runtime: python-direct
-      fields:
-          - id: currencyCode
-            name: Currency Code
-            description: Currency code of oracle to create
-            field_type: text
-          - id: updatePeriod
-            name: Update Period (sec.)
-            description: Oracle update period in seconds.
-            field_type: text
+      fields: []

--- a/daml.yaml
+++ b/daml.yaml
@@ -1,15 +1,10 @@
 ## Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
 ## SPDX-License-Identifier: Apache-2.0
 
-sdk-version: 1.4.0
+sdk-version: 1.11.1
 name: dabl-integration-coindesk
-version: 1.0.0
+version: 1.1.0
 source: daml/Modules.daml
-parties:
-- Alice
-- Bob
-exposed-modules:
-- CoinDesk.PriceRequest
 dependencies:
 - daml-prim
 - daml-stdlib

--- a/daml/CoinDesk/PriceData.daml
+++ b/daml/CoinDesk/PriceData.daml
@@ -1,0 +1,11 @@
+-- Copyright (c) 2014-2021, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- SPDX-License-Identifier: Apache-2.0
+
+module CoinDesk.PriceData where
+
+data MarketPrice = MarketPrice
+  with
+    currencyCode     : Text
+    updatedAt        : Time
+    rate             : Decimal
+  deriving (Eq, Show)

--- a/daml/CoinDesk/PriceOracle.daml
+++ b/daml/CoinDesk/PriceOracle.daml
@@ -1,48 +1,45 @@
--- Copyright (c) 2014-2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- Copyright (c) 2014-2021, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- SPDX-License-Identifier: Apache-2.0
-
-daml 1.2
 
 module CoinDesk.PriceOracle where
 
-template CurrentPriceOracle
+import CoinDesk.PriceData
+
+template PriceOraclePrice
   with
     integrationParty : Party
-    currencyCode     : Text
-    updatedAt        : Time
-    rate             : Decimal
+    price            : MarketPrice
   where
     signatory integrationParty
 
-    key (integrationParty, currencyCode) : (Party, Text)
+    key (integrationParty, price.currencyCode) : (Party, Text)
     maintainer key._1
 
     controller integrationParty can
-      CurrentPriceOracle_Update : ContractId CurrentPriceOracle
+      CurrentPriceOracle_Update : ContractId PriceOraclePrice
         with
-          newUpdatedAt : Time
+          newUpdatedAt : Time 
           newRate      : Decimal
         do
-          create CurrentPriceOracle with
-            integrationParty
-            currencyCode
-            updatedAt=newUpdatedAt
-            rate=newRate
+          create this with 
+            price = price with
+              updatedAt = newUpdatedAt
+              rate = newRate
 
-template CurrentPriceOracleUpdater
+template PriceOracleRequest
   with
     integrationParty : Party
+    currencyCode : Text
   where
     signatory integrationParty
 
     controller integrationParty can
-      CurrentPriceOracleUpdater_Update : ContractId CurrentPriceOracle
+      nonconsuming CurrentPriceOracleUpdater_Update : ContractId PriceOraclePrice
         with
-           currencyCode     : Text
            updatedAt        : Time
            rate             : Decimal
         do
-          currentCid <- lookupByKey @CurrentPriceOracle (integrationParty, currencyCode)
+          currentCid <- lookupByKey @PriceOraclePrice (integrationParty, currencyCode)
 
           case currentCid of
             Some cid ->
@@ -52,6 +49,6 @@ template CurrentPriceOracleUpdater
                   newUpdatedAt=updatedAt
                   newRate=rate
             None ->
-              create CurrentPriceOracle with
+              create PriceOraclePrice with
                 integrationParty
-                ..
+                price = MarketPrice with ..

--- a/daml/CoinDesk/PriceRequest.daml
+++ b/daml/CoinDesk/PriceRequest.daml
@@ -1,10 +1,9 @@
--- Copyright (c) 2014-2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- Copyright (c) 2014-2021, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- SPDX-License-Identifier: Apache-2.0
-
-daml 1.2
 
 module CoinDesk.PriceRequest where
 
+import CoinDesk.PriceData
 
 template PriceRequest
   with
@@ -22,10 +21,8 @@ template PriceRequest
         do
           create PriceResponseSuccess with
             integrationParty
-            currencyCode
             continuationId
-            updatedAt = updatedAt
-            rate = rate
+            price = MarketPrice with ..
 
       PriceRequest_RespondFailure: ContractId PriceResponseFailure
         with
@@ -43,10 +40,8 @@ template PriceRequest
 template PriceResponseSuccess
   with
     integrationParty : Party
-    currencyCode     : Text
     continuationId   : Int
-    updatedAt        : Time
-    rate             : Decimal
+    price            : MarketPrice
   where
     signatory integrationParty
 

--- a/daml/Modules.daml
+++ b/daml/Modules.daml
@@ -1,7 +1,5 @@
--- Copyright (c) 2020, Digital Asset (Switzerland) GmbH and/or its affiliates.
+-- Copyright (c) 2020-2021, Digital Asset (Switzerland) GmbH and/or its affiliates.
 -- SPDX-License-Identifier: Apache-2.0
-
-daml 1.2
 
 module Modules where
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,1 @@
-./lib/PyYAML-5.3.1.tar.gz
-dazl==7.0.2
-yarl==1.5.1
-multidict==4.7.6
-daml_dit_api==0.2.0
-daml_dit_if==0.2.0
+daml_dit_if==0.4.1

--- a/src/core_int/integration_coindesk_price.py
+++ b/src/core_int/integration_coindesk_price.py
@@ -13,7 +13,7 @@ from aiohttp import ClientSession
 from dazl import create_and_exercise, exercise
 from dazl.model.core import ContractData
 
-from daml_dit_api import \
+from daml_dit_if.api import \
     IntegrationEnvironment, IntegrationEvents
 
 
@@ -25,6 +25,8 @@ def normalize_coindesk_date(cd):
 
 
 async def issue_coindesk_request(currencyCode):
+    currencyCode = currencyCode.strip().upper()
+
     if len(currencyCode) != 3:
         return {
             'success': False,
@@ -56,9 +58,9 @@ def integration_coindesk_price_request_main(
 
     @events.ledger.contract_created('CoinDesk.PriceRequest:PriceRequest')
     async def on_contract_created(event):
-        LOG.info('on_contract_created: %r', event)
+        LOG.debug('Noticed new price request: %r', event)
 
-        currencyCode = event.cdata['currencyCode'].strip().upper()
+        currencyCode = event.cdata['currencyCode']
 
         resp = await issue_coindesk_request(currencyCode)
 
@@ -74,29 +76,50 @@ def integration_coindesk_price_request_main(
             })
 
 
-@dataclass
-class IntegrationCoinDeskPriceOracleEnv(IntegrationEnvironment):
-    currencyCode: str
-    updatePeriod: int
+async def update_oracle_commands(cid, currencyCode: str):
+    LOG.debug('update_oracle_commands: %r, %r', cid, currencyCode)
+    resp = await issue_coindesk_request(currencyCode)
 
+    if resp['success']:
+        return [exercise(cid, 'CurrentPriceOracleUpdater_Update', {
+            'updatedAt': resp['updatedAt'],
+            'rate': resp['rate']
+        })]
+    else:
+        LOG.error('Invalid coindesk response (status: %r, body: %r)',
+                  resp['httpStatusCode'], resp['httpResponseBody'])
+        return []
 
 def integration_coindesk_price_oracle_main(
-        env: 'IntegrationCoinDeskPriceOracleEnv',
+        env: 'IntegrationEnvironment',
         events: 'IntegrationEvents'):
 
-    @events.time.periodic_interval(env.updatePeriod)
+    active_oracles = {}
+
+    @events.ledger.contract_created('CoinDesk.PriceOracle:PriceOracleRequest')
+    async def on_contract_created(event):
+        LOG.debug('Noticed oracle request contract: %r (%r)', event.cid, event.cdata)
+
+        currencyCode = event.cdata['currencyCode']
+
+        active_oracles[event.cid] = currencyCode
+
+        return await update_oracle_commands(event.cid, currencyCode)
+
+    @events.ledger.contract_archived('CoinDesk.PriceOracle.PriceOracleRequest')
+    async def on_ledger_archived(event):
+        LOG.debug('Archived oracle request contract: %r', event.cid)
+        active_oracles.pop(event.cid, None)
+
+    @events.time.periodic_interval(30)
     async def poll_coindesk():
-        resp = await issue_coindesk_request(env.currencyCode.upper())
 
-        if not resp['success']:
-            LOG.error('Invalid coindesk response (status: %r, body: %r)',
-                      resp['httpStatusCode'], resp['httpResponseBody'])
-            return []
+        cmds = []
 
-        return [create_and_exercise(
-            'CoinDesk.PriceOracle.CurrentPriceOracleUpdater',
-            {'integrationParty': env.party},
-            'CurrentPriceOracleUpdater_Update',
-            {'currencyCode': env.currencyCode,
-             'updatedAt': resp['updatedAt'],
-             'rate': resp['rate']})]
+        for (cid, currencyCode) in active_oracles.items():
+            cmds.extend(await update_oracle_commands(cid, currencyCode))
+
+        LOG.debug('Update commands: %r', cmds)
+
+        return cmds
+


### PR DESCRIPTION
This also updates to DAML SDK 1.11.1 and unifies the on-ledger representation of price data from both request/response and oracle sources.