### PR TITLE
Unify the oracle and on-demand integrations.

### DIFF
--- a/dabl-meta.yaml
+++ b/dabl-meta.yaml
@@ -4,7 +4,7 @@
 catalog:
     name: dabl-integration-coindesk
     group_id: com.digitalasset
-    version: 0.7.0
+    version: 0.7.5
     short_description: CoinDesk
     description: BTC Price Queries
     author: Digital Asset (Switzerland) GmbH
@@ -12,15 +12,9 @@ catalog:
     tags: [ integration ]
     icon_file: coindesk-icon.png
 integration_types:
-    - id: com.projectdabl.integrations.coindesk.price_request
-      name: CoinDesk Price Query
-      description: Queries CoinDesk for the price of BTC in a specific unit of currency.
-      entrypoint: core_int.integration_coindesk_price:integration_coindesk_price_request_main
-      runtime: python-direct
-      fields: []
-    - id: com.projectdabl.integrations.coindesk.oracle
-      name: CoinDesk Price Oracle
-      description: Periodically queries CoinDesk for the price of BTC in a specific unit of currency and updates a CurrentPrice contract on the ledger with that price.
-      entrypoint: core_int.integration_coindesk_price:integration_coindesk_price_oracle_main
+    - id: com.projectdabl.integrations.coindesk.btc_price
+      name: CoinDesk Price
+      description: Request/Response and Periodic CoinDesk queries for the price of BTC.
+      entrypoint: core_int.integration_coindesk_price:integration_coindesk_main
       runtime: python-direct
       fields: []


### PR DESCRIPTION
Without configuration settings for the oracle integration, there's no longer any point in separating it out into a separate integration type.